### PR TITLE
feat: Set relative path for springwolf-ui gh pages deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,10 @@ jobs:
 
       - name: Build gh-pages
         if: github.ref == 'refs/heads/master'
-        run: ./gradlew npm_run_build-dev
-      - name: Create index.html
-        if: github.ref == 'refs/heads/master'
-        run: cp dist/springwolf-ui/asyncapi-ui.html dist/springwolf-ui/index.html 
+        run: |
+          ./gradlew npmInstall
+          npx ng build --base-href=./
+          cp dist/springwolf-ui/asyncapi-ui.html dist/springwolf-ui/index.html
       - name: Deploy to gh pages 🚀
         if: github.ref == 'refs/heads/master'
         uses: JamesIves/github-pages-deploy-action@v4

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build --prod --base-href=./",
-    "build-dev": "ng build --base-href=./",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",

--- a/src/_redirects
+++ b/src/_redirects
@@ -1,2 +1,7 @@
 # Redirects from what the browser requests to what we serve
-/              /asyncapi-ui.html
+# Usage with netlify for dev build with mock data:
+#   Build command: ng build --base-href=/springwolf-ui/ && mv dist/springwolf-ui/_redirects dist/_redirects
+#   Publish directory: dist/
+
+/              /springwolf-ui/asyncapi-ui.html
+/springwolf-ui /springwolf-ui/asyncapi-ui.html


### PR DESCRIPTION
springwolf-ui is deployed under the springwolf-ui/ path, like https://springwolf.github.io/springwolf-ui/